### PR TITLE
feat(cognito): add identity pool authentication provider support

### DIFF
--- a/src/constructs/authentication.ts
+++ b/src/constructs/authentication.ts
@@ -362,6 +362,16 @@ export class CognitoAuthentication extends Construct implements ICognitoAuthenti
       key: `${CFN_OUTPUT_SUFFIX_AUTH_USERPOOL_CLIENTID}${id}`,
       value: client.userPoolClientId,
     });
+
+    if (this.identityPool) {
+      this.identityPool.addUserPoolAuthentication(
+        new identitypool.UserPoolAuthenticationProvider({
+          userPool: this.userpool,
+          userPoolClient: client,
+        }),
+      );
+    }
+
     return client;
   }
 


### PR DESCRIPTION
Enable adding Cognito User Pool authentication to an Identity Pool by introducing a method to add a User Pool authentication provider when an Identity Pool is configured.